### PR TITLE
修复一个方法重写检查的 bug

### DIFF
--- a/src/main/java/mod/chloeprime/tacinteractkey/util/InheritanceChecker.java
+++ b/src/main/java/mod/chloeprime/tacinteractkey/util/InheritanceChecker.java
@@ -25,17 +25,56 @@ public class InheritanceChecker<T> {
     private final Class<? super T> realBaseType;
     private final ClassValue<Boolean> CACHE = new ClassValue<>() {
         @Override
+        @SuppressWarnings("unchecked")
         protected Boolean computeValue(Class<?> type) {
-            return !realBaseType.equals(getDeclareClass(type, methodName, paramTypes));
+            return !realBaseType.equals(getDeclareClass((Class<T>) type, methodName, paramTypes));
         }
     };
 
     @SuppressWarnings("unchecked")
-    private static <T> Class<? super T> getDeclareClass(Class<T> type, String methodName, Class<?>... paramTypes) {
+    private Class<? super T> getDeclareClass(Class<T> type, String methodName, Class<?>[] paramTypes) {
+        Method method;
         try {
-            return (Class<? super T>) getDeclaredMethod(type, methodName, paramTypes).getDeclaringClass();
+            method = getDeclaredMethod(type, methodName, paramTypes);
         } catch (NoSuchMethodException ex) {
-            throw new RuntimeException(ex);
+            // While MobEntity.mobInteract(...) is a protected method,
+            // throwing NoSuchMethodException means the method has not
+            // been overridden in given class
+            method = getDeclaredMethodFromSuperClass(type, methodName, paramTypes);
+        }
+        return (Class<? super T>) method.getDeclaringClass();
+    }
+
+    // Walk over super classes to check override status
+    private Method getDeclaredMethodFromSuperClass(Class<?> type, String methodName, Class<?>... paramTypes) {
+        Class<?> temp = type.getSuperclass();
+
+        while (temp != this.realBaseType && temp != Object.class && temp != null) {
+            Method method;
+            try {
+                method = temp.getMethod(methodName, paramTypes);
+                return method;
+            }
+            catch (NoSuchMethodException ignored) {
+                try {
+                    method = temp.getDeclaredMethod(methodName, paramTypes);
+                    if (!method.trySetAccessible()) {
+                        throw new IllegalArgumentException("Inaccessible Method");
+                    }
+                    return method;
+                }
+                catch (NoSuchMethodException pass) {
+                    temp = temp.getSuperclass();
+                }
+            }
+        }
+
+        try {
+            return realBaseType.getDeclaredMethod(methodName, paramTypes);
+        }
+        catch (NoSuchMethodException e) {
+            // No way
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
InheritanceChecker 的原始代码在进行方法重写检查时仅会检查当前类对基类方法的重写情况，而不会检查类继承树上的每一个节点的重写情况，当出现复杂的继承和/或重写关系时极容易产生误判
此外，原始代码还会在检查 Mob#mobInteract 方法时不断抛出异常污染客户端日志（可以在持枪时对准凋零骷髅等生物时复现此问题，原因为 Class#getDeclaredMethod 方法和 Class#getMethod 方法均会在获取子类未重写的 protected 基类方法时抛出 NoSuchMethodException ，导致始终不能获取对方法进行重写的类对象）
我在 InheritanceChecker 中添加了一个工具方法（ InheritanceChecker#getDeclaredMethodFromSuperClass ），当 InheritanceChecker#getDeclaredMethod 抛出异常时调用该工具方法遍历对应子类到基类的类继承树，以确定子类是否重写过对应方法